### PR TITLE
Added flatcar & static linux distro support

### DIFF
--- a/crawler/core/exporter.py
+++ b/crawler/core/exporter.py
@@ -35,6 +35,10 @@ def export_image_catalog(
             image_template_file.close()
 
             for release in source["releases"]:
+                #normalize base url again
+                if not release["baseURL"].endswith("/"):
+                    release["baseURL"] = release["baseURL"] + "/"
+
                 # TODO check empty catalog (still necessary after add updated sources?)
                 release_catalog = read_release_from_catalog(
                     connection, distribution, release["name"]

--- a/crawler/updater/service.py
+++ b/crawler/updater/service.py
@@ -28,7 +28,17 @@ def release_update_check(release, last_checksum):
 
     if current_checksum != last_checksum:
         image_url = base_url + release["releasepath"] + "/" + imagename
+
         image_filedate = url_get_last_modified(image_url)
+
+        if "immutable" in release and release["immutable"]:
+            update = {}
+            update["release_date"] = image_filedate
+            update["url"] = image_url
+            update["version"] = release['name']
+            update["checksum"] = current_checksum
+
+            return update
 
         image_metadata = web_get_current_image_metadata(release, image_filedate)
         if image_metadata is not None:

--- a/crawler/web/directory.py
+++ b/crawler/web/directory.py
@@ -95,7 +95,7 @@ def web_get_current_image_metadata(release, image_filedate):
     version = image_filedate.replace("-", "")
 
     # get directory content
-    if "debian" in release["imagename"] or "ubuntu" in release["imagename"] or "flatcar" in release["imagename"]:
+    if "debian" in release["imagename"] or "ubuntu" in release["imagename"]:
         requestURL = release["baseURL"]
     else:
         requestURL = release["baseURL"] + "/" + release["releasepath"]

--- a/crawler/web/directory.py
+++ b/crawler/web/directory.py
@@ -45,6 +45,8 @@ def release_build_image_url(release, versionpath, version):
         )
     elif "AlmaLinux" in release["imagename"]:
         return base_url + release["releasepath"] + "/" + versionpath
+    elif "flatcar" in release["imagename"]:
+        return base_url + release["releasepath"] + "/" + release["imagename"] + "." + release["extension"]
     # we do not know this distribution
     else:
         return None
@@ -93,10 +95,10 @@ def web_get_current_image_metadata(release, image_filedate):
     version = image_filedate.replace("-", "")
 
     # get directory content
-    if "debian" in release["imagename"] or "ubuntu" in release["imagename"]:
+    if "debian" in release["imagename"] or "ubuntu" in release["imagename"] or "flatcar" in release["imagename"]:
         requestURL = release["baseURL"]
     else:
-        requestURL = release["baseURL"] + release["releasepath"]
+        requestURL = release["baseURL"] + "/" + release["releasepath"]
 
     request = requests.get(requestURL, allow_redirects=True)
     soup = BeautifulSoup(request.text, "html.parser")

--- a/etc/image-sources.yaml
+++ b/etc/image-sources.yaml
@@ -80,6 +80,7 @@ sources:
         extension: qcow2
         checksumname: CHECKSUM
         algorithm: sha256
+        limit: 1
       - name: '9'
         codename: 'none'
         baseURL: https://repo.almalinux.org/almalinux/9/
@@ -88,7 +89,7 @@ sources:
         extension: qcow2
         checksumname: CHECKSUM
         algorithm: sha256
-
+        limit: 1
 
   - name: Flatcar
     vendor: "Flatcar"

--- a/etc/image-sources.yaml
+++ b/etc/image-sources.yaml
@@ -88,3 +88,17 @@ sources:
         extension: qcow2
         checksumname: CHECKSUM
         algorithm: sha256
+
+
+  - name: Flatcar
+    vendor: "Flatcar"
+    releases:
+      - name: 3510.2.1
+        codename: 3510.2.1
+        baseURL: https://stable.release.flatcar-linux.net/amd64-usr
+        releasepath: 3510.2.1
+        imagename: flatcar_production_openstack_image
+        extension: img.gz
+        checksumname: flatcar_production_openstack_image.img.gz.DIGESTS
+        algorithm: md5
+        immutable: true

--- a/templates/flatcar.yml.j2
+++ b/templates/flatcar.yml.j2
@@ -1,0 +1,34 @@
+
+  - name: {{ catalog['name'] }} {{ catalog['os_version'] }}
+    format: qcow2
+    login: core
+    min_disk: 10
+    min_ram: 512
+    status: active
+    visibility: public
+    multi: true
+    meta:
+      architecture: x86_64
+      hypervisor_type: qemu
+      hw_disk_bus: scsi
+      hw_rng_model: virtio
+      hw_scsi_model: virtio-scsi
+      hw_qemu_guest_agent: yes
+      hw_watchdog_action: reset
+      replace_frequency: monthly
+      hotfix_hours: 0
+      uuid_validity: last-3
+      provided_until: none
+      os_distro: almalinux
+      os_version: '{{ catalog['os_version'] }}'
+    tags: []
+    latest_checksum_url: {{ metadata['baseURL'] }}{{ metadata['releasepath'] }}/{{ metadata['checksumname'] }}
+    latest_url: {{ metadata['baseURL'] }}{{ metadata['releasepath'] }}/{{ metadata['imagename'] }}.{{ metadata['extension'] }}
+    versions:{% for release_version in catalog['versions'] %}
+      - version: '{{ release_version }}'
+        url: {{ catalog['versions'][release_version]['url'] }}
+        checksum: {{ catalog['versions'][release_version]['checksum'] }}
+        build_date: {{ catalog['versions'][release_version]['release_date'] }}
+        image_source: {{ catalog['versions'][release_version]['url'] }}
+        image_description: https://www.flatcar.org/releases
+{%- endfor %}


### PR DESCRIPTION
This PR adds support for Flatcar and other distributions, which use atomic versioning (the version / files released never change).

Operators can now specify the "immutable" flag for a release, which will instruct the image crawler to skip discovery of the latest version via modified dates etc. and just construct the image url as follows:
Release Base URL + Release Path + Image Name + Extension

For example:
Flatcar Release Config can look like this:
~~~
 - name: Flatcar
    vendor: "Flatcar"
    releases:
      - name: 3510.2.1
        codename: 3510.2.1
        baseURL: https://stable.release.flatcar-linux.net/amd64-usr
        releasepath: 3510.2.1
        imagename: flatcar_production_openstack_image
        extension: img.gz
        checksumname: flatcar_production_openstack_image.img.gz.DIGESTS
        algorithm: md5
        immutable: true
~~~
which will result in the image url:
https://stable.release.flatcar-linux.net/amd64-usr/3510.2.1/flatcar_production_openstack_image.img.gz
