### PR TITLE
Fix/handle not found

### DIFF
--- a/crawler/updater/alma.py
+++ b/crawler/updater/alma.py
@@ -113,7 +113,12 @@ def alma_update_check(release, last_checksum):
 
         logger.debug("image_filedate:" + image_filedate)
 
-        image_metadata = get_metadata(release, image_filedate)
+        try:
+            image_metadata = get_metadata(release, image_filedate)
+        except:
+            logger.warning("got no metadata")
+            return None
+
         if image_metadata is not None:
             logger.debug("got metadata")
             update = {}

--- a/crawler/updater/debian.py
+++ b/crawler/updater/debian.py
@@ -166,7 +166,11 @@ def debian_update_check(release, last_checksum):
 
         logger.debug("image_filedate: " + image_filedate)
 
-        image_metadata = get_metadata(release, image_filedate)
+        try:
+            image_metadata = get_metadata(release, image_filedate)
+        except:
+            logger.warning("got no metadata")
+            return None
         if image_metadata is not None:
             logger.debug("got metadata")
             update = {}
@@ -176,7 +180,7 @@ def debian_update_check(release, last_checksum):
             update["checksum"] = current_checksum
             return update
         else:
-            logger.warn("got no metadata")
+            logger.warning("got no metadata")
             return None
 
     return None

--- a/crawler/updater/fedora.py
+++ b/crawler/updater/fedora.py
@@ -112,7 +112,7 @@ def fedora_update_check(release, last_checksum):
     image_filename = get_image_filename(release, images_url)
 
     if image_filename is None:
-        logger.warn("did not find any matching filenames")
+        logger.warning("did not find any matching filenames")
         return None
 
     logger.debug("image_filename: " +  image_filename)
@@ -204,7 +204,7 @@ def fedora_crawl_release(release):
         image_filename = get_image_filename(release, images_url)
 
         if image_filename is None:
-            logger.warn("did not find any matching filenames")
+            logger.warning("did not find any matching filenames")
             return None
 
         logger.debug("image_filename: " +  image_filename)

--- a/crawler/updater/flatcar.py
+++ b/crawler/updater/flatcar.py
@@ -101,7 +101,12 @@ def flatcar_update_check(release, last_checksum):
 
         logger.debug("image_filedate: " + image_filedate)
 
-        image_metadata = get_metadata(release, image_filedate)
+        try:
+            image_metadata = get_metadata(release, image_filedate)
+        except:
+            logger.warning("got no metadata")
+            return None
+
         if image_metadata is not None:
             logger.debug("got metadata")
             update = {}
@@ -111,7 +116,7 @@ def flatcar_update_check(release, last_checksum):
             update["checksum"] = current_checksum
             return update
         else:
-            logger.warn("got no metadata")
+            logger.warning("got no metadata")
             return None
 
     return None

--- a/crawler/updater/rocky.py
+++ b/crawler/updater/rocky.py
@@ -136,7 +136,11 @@ def rocky_update_check(release, last_checksum):
     if current_checksum != last_checksum:
         logger.debug("current_checksum " + current_checksum + " differs from last_checksum " + last_checksum)
 
-        image_metadata = get_metadata(release)
+        try:
+            image_metadata = get_metadata(release)
+        except:
+            logger.warning("got no metadata")
+            return None
         if image_metadata is not None:
             logger.debug("got metadata")
             update = {}

--- a/crawler/updater/ubuntu.py
+++ b/crawler/updater/ubuntu.py
@@ -167,7 +167,11 @@ def ubuntu_update_check(release, last_checksum):
 
         logger.debug("image_filedate: " + image_filedate)
 
-        image_metadata = get_metadata(release, image_filedate)
+        try:
+            image_metadata = get_metadata(release, image_filedate)
+        except:
+            logger.warning("got no metadata")
+            return None
         if image_metadata is not None:
             logger.debug("got metadata")
             update = {}
@@ -177,7 +181,7 @@ def ubuntu_update_check(release, last_checksum):
             update["checksum"] = current_checksum
             return update
         else:
-            logger.warn("got no metadata")
+            logger.warning("got no metadata")
             return None
 
     return None


### PR DESCRIPTION
The flatcar upstream URL is not working, so prevent the image-crawler from failing all images after flatcar by handling exception gracefully.
Also found a syntax error `logger.warn()` -> `logger.warning()`.