### PR TITLE
Feat/add os purpose

### DIFF
--- a/crawler/core/exporter.py
+++ b/crawler/core/exporter.py
@@ -26,6 +26,8 @@ def export_image_catalog(
     for source in sources_catalog["sources"]:
         if source["name"] in updated_sources:
             distribution = source["name"]
+            # purpose = source.get("purpose", "generic")
+            purpose = source["purpose"]
             logger.info("Exporting image catalog for " + distribution)
 
             catalog_export = ""
@@ -58,6 +60,7 @@ def export_image_catalog(
                     release_catalog["os_distro"] = distribution.lower()
                     release_catalog["os_version"] = release["name"]
                     release_catalog["codename"] = release["codename"]
+                    release_catalog["purpose"] = purpose
                     logger.debug("Rendering template for " +
                                  release_catalog["name"] + " " +
                                  release_catalog["os_version"])
@@ -112,6 +115,8 @@ def export_image_catalog_all(
 
     for source in sources_catalog["sources"]:
         distribution = source["name"]
+        # purpose = source.get("purpose", "generic")
+        purpose = source["purpose"]
         logger.info("Exporting image catalog for " + distribution)
 
         catalog_export = ""
@@ -138,6 +143,7 @@ def export_image_catalog_all(
                 release_catalog["os_distro"] = distribution.lower()
                 release_catalog["os_version"] = release["name"]
                 release_catalog["codename"] = release["codename"]
+                release_catalog["purpose"] = purpose
                 logger.debug("Rendering template for " +
                              release_catalog["name"] + " " +
                              release_catalog["os_version"])

--- a/crawler/updater/alma.py
+++ b/crawler/updater/alma.py
@@ -113,7 +113,12 @@ def alma_update_check(release, last_checksum):
 
         logger.debug("image_filedate:" + image_filedate)
 
-        image_metadata = get_metadata(release, image_filedate)
+        try:
+            image_metadata = get_metadata(release, image_filedate)
+        except:
+            logger.warning("got no metadata")
+            return None
+
         if image_metadata is not None:
             logger.debug("got metadata")
             update = {}

--- a/crawler/updater/debian.py
+++ b/crawler/updater/debian.py
@@ -166,7 +166,11 @@ def debian_update_check(release, last_checksum):
 
         logger.debug("image_filedate: " + image_filedate)
 
-        image_metadata = get_metadata(release, image_filedate)
+        try:
+            image_metadata = get_metadata(release, image_filedate)
+        except:
+            logger.warning("got no metadata")
+            return None
         if image_metadata is not None:
             logger.debug("got metadata")
             update = {}
@@ -176,7 +180,7 @@ def debian_update_check(release, last_checksum):
             update["checksum"] = current_checksum
             return update
         else:
-            logger.warn("got no metadata")
+            logger.warning("got no metadata")
             return None
 
     return None

--- a/crawler/updater/fedora.py
+++ b/crawler/updater/fedora.py
@@ -112,7 +112,7 @@ def fedora_update_check(release, last_checksum):
     image_filename = get_image_filename(release, images_url)
 
     if image_filename is None:
-        logger.warn("did not find any matching filenames")
+        logger.warning("did not find any matching filenames")
         return None
 
     logger.debug("image_filename: " +  image_filename)
@@ -204,7 +204,7 @@ def fedora_crawl_release(release):
         image_filename = get_image_filename(release, images_url)
 
         if image_filename is None:
-            logger.warn("did not find any matching filenames")
+            logger.warning("did not find any matching filenames")
             return None
 
         logger.debug("image_filename: " +  image_filename)

--- a/crawler/updater/flatcar.py
+++ b/crawler/updater/flatcar.py
@@ -101,7 +101,12 @@ def flatcar_update_check(release, last_checksum):
 
         logger.debug("image_filedate: " + image_filedate)
 
-        image_metadata = get_metadata(release, image_filedate)
+        try:
+            image_metadata = get_metadata(release, image_filedate)
+        except:
+            logger.warning("got no metadata")
+            return None
+
         if image_metadata is not None:
             logger.debug("got metadata")
             update = {}
@@ -111,7 +116,7 @@ def flatcar_update_check(release, last_checksum):
             update["checksum"] = current_checksum
             return update
         else:
-            logger.warn("got no metadata")
+            logger.warning("got no metadata")
             return None
 
     return None

--- a/crawler/updater/rocky.py
+++ b/crawler/updater/rocky.py
@@ -136,7 +136,11 @@ def rocky_update_check(release, last_checksum):
     if current_checksum != last_checksum:
         logger.debug("current_checksum " + current_checksum + " differs from last_checksum " + last_checksum)
 
-        image_metadata = get_metadata(release)
+        try:
+            image_metadata = get_metadata(release)
+        except:
+            logger.warning("got no metadata")
+            return None
         if image_metadata is not None:
             logger.debug("got metadata")
             update = {}

--- a/crawler/updater/service.py
+++ b/crawler/updater/service.py
@@ -107,6 +107,7 @@ def image_update_service(connection, source):
             logger.info("New release " + catalog_update["version"])
             # catalog_update anreichern mit _allen_ Daten für die DB
             catalog_update["distribution_name"] = source["name"]
+            # catalog_update["purpose"] = source.get("purpose", "generic")
             if "Fedora" in release["imagename"]:
                 catalog_update["name"] = source["name"] + " " + catalog_update["release_id"]
                 catalog_update["distribution_release"] = catalog_update["release_id"]

--- a/crawler/updater/ubuntu.py
+++ b/crawler/updater/ubuntu.py
@@ -167,7 +167,11 @@ def ubuntu_update_check(release, last_checksum):
 
         logger.debug("image_filedate: " + image_filedate)
 
-        image_metadata = get_metadata(release, image_filedate)
+        try:
+            image_metadata = get_metadata(release, image_filedate)
+        except:
+            logger.warning("got no metadata")
+            return None
         if image_metadata is not None:
             logger.debug("got metadata")
             update = {}
@@ -177,7 +181,7 @@ def ubuntu_update_check(release, last_checksum):
             update["checksum"] = current_checksum
             return update
         else:
-            logger.warn("got no metadata")
+            logger.warning("got no metadata")
             return None
 
     return None

--- a/etc/image-sources.yaml
+++ b/etc/image-sources.yaml
@@ -3,6 +3,7 @@ sources:
 
   - name: Ubuntu
     vendor: "Canonical Ltd."
+    purpose: generic
     releases:
       - name: '20.04'
         codename: focal
@@ -24,6 +25,7 @@ sources:
 
   - name: Ubuntu Minimal
     vendor: "Canonical Ltd."
+    purpose: minimal
     releases:
       - name: '20.04'
         codename: focal
@@ -44,6 +46,7 @@ sources:
 
   - name: Debian
     vendor: "Debian Community"
+    purpose: generic
     releases:
       - name: '10'
         codename: buster
@@ -72,6 +75,7 @@ sources:
 
   - name: AlmaLinux
     vendor: "AlmaLinux OS"
+    purpose: generic
     releases:
       - name: '8'
         codename: 'none'
@@ -94,6 +98,7 @@ sources:
 
   - name: Flatcar
     vendor: "Kinvolk"
+    purpose: k8snode
     releases:
       - name: 'stable'
         codename: 'none'
@@ -106,6 +111,7 @@ sources:
 
   - name: Fedora
     vendor: "Fedora Project"
+    purpose: generic
     releases:
       - name: 'all'
         codename: none
@@ -120,6 +126,7 @@ sources:
 
   - name: RockyLinux
     vendor: "Rocky Linux Foundation"
+    purpose: generic
     releases:
       - name: '8'
         codename: 'none'

--- a/image-crawler.py
+++ b/image-crawler.py
@@ -7,6 +7,7 @@
 # maintaining an image catalog
 #
 # 2023-06-11 v0.4.0 christian.stelter@plusserver.com
+# 2026-02-18 v0.4.1 s7n@garloff.de
 
 import argparse
 import sys
@@ -84,7 +85,7 @@ def main():
     logger.remove()
     logger.add(sys.stderr, format=log_format, level=log_level, colorize=True)
 
-    logger.info("plusserver Image Crawler v0.4.0 started")
+    logger.info("plusserver Image Crawler v0.4.1 started")
 
     # read configuration
     if args.config is not None:

--- a/templates/almalinux.yml.j2
+++ b/templates/almalinux.yml.j2
@@ -21,6 +21,7 @@
       provided_until: none
       os_distro: almalinux
       os_version: '{{ catalog['os_version'] }}'
+      os_purpose: '{{ catalog['purpose'] }}'
     tags: []
     latest_checksum_url: {{ metadata['baseURL'] }}{{ metadata['releasepath'] }}/{{ metadata['checksumname'] }}
     latest_url: {{ metadata['baseURL'] }}{{ metadata['releasepath'] }}/{{ metadata['imagename'] }}.{{ metadata['extension'] }}

--- a/templates/debian.yml.j2
+++ b/templates/debian.yml.j2
@@ -21,6 +21,7 @@
       provided_until: none
       os_distro: debian
       os_version: '{{ catalog['os_version'] }}'
+      os_purpose: '{{ catalog['purpose'] }}'
     tags: []
     latest_checksum_url: {{ metadata['baseURL'] }}{{ metadata['releasepath'] }}/{{ metadata['checksumname'] }}
     latest_url: {{ metadata['baseURL'] }}{{ metadata['releasepath'] }}/{{ metadata['imagename'] }}.{{ metadata['extension'] }}

--- a/templates/fedora.yml.j2
+++ b/templates/fedora.yml.j2
@@ -21,6 +21,7 @@
       provided_until: none
       os_distro: fedora
       os_version: '{{ catalog['versions'][release_version]['distribution_release'] }}'
+      os_purpose: '{{ catalog['purpose'] }}'
     tags: []
     versions:
       - version: '{{ release_version }}'

--- a/templates/flatcar.yml.j2
+++ b/templates/flatcar.yml.j2
@@ -21,6 +21,7 @@
       provided_until: none
       os_distro: flatcar
       os_version: '{{ catalog['os_version'] }}'
+      os_purpose: '{{ catalog['purpose'] }}'
     tags: []
     latest_checksum_url: {{ metadata['baseURL'] }}{{ metadata['releasepath'] }}/{{ metadata['checksumname'] }}
     latest_url: {{ metadata['baseURL'] }}{{ metadata['releasepath'] }}/{{ metadata['imagename'] }}.{{ metadata['extension'] }}

--- a/templates/rockylinux.yml.j2
+++ b/templates/rockylinux.yml.j2
@@ -21,6 +21,7 @@
       provided_until: none
       os_distro: rocky
       os_version: '{{ catalog['os_version'] }}'
+      os_purpose: '{{ catalog['purpose'] }}'
     tags: []
     latest_checksum_url: {{ metadata['baseURL'] }}{{ catalog['os_version'] }}/{{ metadata['imagepath'] }}/{{ metadata['checksumname'] }}
     latest_url: {{ metadata['baseURL'] }}{{ catalog['os_version'] }}/{{ metadata['imagepath'] }}/{{ metadata['imagename'] }}.{{ metadata['extension'] }}

--- a/templates/ubuntu.yml.j2
+++ b/templates/ubuntu.yml.j2
@@ -21,6 +21,7 @@
       provided_until: none
       os_distro: ubuntu
       os_version: '{{ catalog['os_version'] }}'
+      os_purpose: '{{ catalog['purpose'] }}'
     tags: []
     latest_checksum_url: {{ metadata['baseURL'] }}{{ metadata['releasepath'] }}/{{ metadata['checksumname'] }}
     latest_url: {{ metadata['baseURL'] }}{{ metadata['releasepath'] }}/{{ metadata['imagename'] }}.{{ metadata['extension'] }}

--- a/templates/ubuntu_minimal.yml.j2
+++ b/templates/ubuntu_minimal.yml.j2
@@ -21,6 +21,7 @@
       provided_until: none
       os_distro: ubuntu
       os_version: '{{ catalog['os_version'] }}'
+      os_purpose: '{{ catalog['purpose'] }}'
     tags: []
     latest_checksum_url: {{ metadata['baseURL'] }}{{ metadata['releasepath'] }}/{{ metadata['checksumname'] }}
     latest_url: {{ metadata['baseURL'] }}{{ metadata['releasepath'] }}/{{ metadata['imagename'] }}.{{ metadata['extension'] }}


### PR DESCRIPTION
This introduces a new `purpose` field per image family in image-sources.
It is propagated into the `os_purpose` property (metadata) for the image.
I made it a requirement rather than defaulting to `generic`, as the latter is too prone to be overlooked and thus supporting sloppiness, eventually resulting in `generic` purpose images that should not be generic.

Implementation Notes:
- The purpose field is not stored in the database. It is static information that does not change with releases ...
- We could have instead hardcoded the os_purpose in the jinja2 templates rather than the image-sources. I find it cleaner to have it in sources, as eventually we might end up using the same template for different purpose images. So let's control it at the source.
- This builds on top of the [last PR](https://github.com/pluscloudopen/openstack-image-crawler/pull/35)